### PR TITLE
Fix Vite condition resolution for Excalidraw CSS

### DIFF
--- a/apps/web/src/components/canvas/CanvasShell.tsx
+++ b/apps/web/src/components/canvas/CanvasShell.tsx
@@ -1,5 +1,5 @@
 import { Excalidraw } from '@excalidraw/excalidraw';
-import '@excalidraw/excalidraw/dist/excalidraw.css';
+import '@excalidraw/excalidraw/index.css';
 import { createLogger } from '@shared-utils';
 import { useCallback, useEffect, useRef } from 'react';
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,11 +7,27 @@ import { defineConfig } from 'vite';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const packageConditionNames = [
+  'style',
+  'development',
+  'production',
+  'import',
+  'module',
+  'browser',
+  'default'
+] as const;
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
       '@shared-utils': resolve(__dirname, '../../packages/shared-utils/src')
+    },
+    conditions: [...packageConditionNames]
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      conditions: [...packageConditionNames]
     }
   },
   server: {

--- a/docs/architecture/2025-09-22T0717Z-excalidraw-css-condition-fix.md
+++ b/docs/architecture/2025-09-22T0717Z-excalidraw-css-condition-fix.md
@@ -1,0 +1,63 @@
+# 2025-09-22T07:17Z — Excalidraw CSS condition resolution architecture
+
+## Context & Baseline AST Overview
+
+### Monorepo structure snapshot
+- `apps/web/`
+  - `src/components/canvas/CanvasShell.tsx`
+    - Imports `Excalidraw` React component from `@excalidraw/excalidraw`.
+    - Imports CSS side effect from `@excalidraw/excalidraw/dist/excalidraw.css`.
+    - Defines `CanvasShell` functional component with props `onAppReady`, `onSnapshot`.
+    - Hooks:
+      - `useRef` to cache `CanvasAPI` reference.
+      - `useEffect` for lifecycle logging via `createLogger` from `@shared-utils`.
+      - `useCallback` wrappers `handleApiRef` and `handleChange` that forward events to props.
+    - Renders `<div className="canvas-shell">` containing `<Excalidraw>`.
+  - `vite.config.ts`
+    - Node ESM config using `defineConfig` from `vite`.
+    - Resolves alias `@shared-utils` to `../../packages/shared-utils/src`.
+    - Registers React plugin.
+    - Server host/port settings.
+- `packages/shared-utils/src`
+  - Provides shared logging utility `createLogger` leveraged by `CanvasShell`.
+
+### Observed issue baseline
+- Vite dev server fails dependency scan when resolving `@excalidraw/excalidraw/dist/excalidraw.css` because the package exports mark the stylesheet behind a non-default condition (`"style"`).
+- Esbuild (used by Vite optimizeDeps) requires explicit opt-in for custom condition names.
+
+## Proposed Architectural Adjustments
+
+1. Update Excalidraw stylesheet import to the exported entry `@excalidraw/excalidraw/index.css` to respect the package's official `exports` map.
+2. Extend Vite resolver awareness of Excalidraw's custom export conditions so CSS subpath resolves in dev and build modes.
+   - Configure `resolve.conditions` to append `"style"`, `"development"`, and `"production"` alongside existing implicit defaults (e.g., `"import"`, `"module"`, `"browser"`, `"default"`).
+3. Align esbuild dependency pre-bundling with the same condition logic.
+   - Set `optimizeDeps.esbuildOptions.conditions` to mirror the resolver condition list, ensuring the dependency scanner can load the stylesheet without errors.
+4. Preserve existing aliases and plugin configuration to avoid regressions.
+
+## Expected Post-change AST delta
+- `CanvasShell.tsx`
+  - Import side effect updated to `@excalidraw/excalidraw/index.css`.
+- `vite.config.ts`
+  - New config nodes:
+    - `resolve.conditions` includes `style`, `development`, `production`, and default-friendly entries (`import`, `module`, `browser`, `default`).
+    - `optimizeDeps.esbuildOptions.conditions` mirrors the same string array for esbuild.
+
+## UML / Mermaid Representations
+
+```mermaid
+flowchart TD
+    CanvasShell[CanvasShell.tsx]
+    ViteConfig[vite.config.ts]
+    ExcalidrawPkg[@excalidraw/excalidraw]
+    SharedUtils[packages/shared-utils/src]
+
+    CanvasShell -- import --> ExcalidrawPkg
+    CanvasShell -- alias --> SharedUtils
+    ViteConfig -- defines --> AliasConfig[Alias @shared-utils]
+    ViteConfig -- sets --> StyleCondition[Resolve & optimizeDeps conditions]
+    StyleCondition -- enables --> ExcalidrawCSS[Resolution of dist/excalidraw.css]
+```
+
+## Alignment Notes
+- No pre-existing hybrid knowledge graph metadata accessible within container; assumed absent. The above representations should be synchronized to any external graph store manually if required.
+- Ensure future architectural updates referencing Excalidraw imports reuse the `style` condition-aware resolution strategy.

--- a/docs/checklists/2025-09-22T0717Z-excalidraw-css-condition-fix.md
+++ b/docs/checklists/2025-09-22T0717Z-excalidraw-css-condition-fix.md
@@ -1,0 +1,8 @@
+# Checklist — 2025-09-22T07:17Z — Excalidraw CSS condition fix
+
+- ✅ Update `apps/web/src/components/canvas/CanvasShell.tsx` to import the stylesheet from `@excalidraw/excalidraw/index.css`.
+- ✅ Update `apps/web/vite.config.ts` `resolve.conditions` to include `'style', 'development', 'production', 'import', 'module', 'browser', 'default'` while keeping existing alias configuration intact.
+- ✅ Ensure `apps/web/vite.config.ts` sets `optimizeDeps.esbuildOptions.conditions` to the same array so esbuild's dependency scanner respects the custom conditions.
+- ✅ Ensure formatting/imports remain valid (run project's formatter if applicable or rely on existing style) and save files.
+- ✅ Execute `pnpm --filter @tljustdraw/web dev` (or equivalent) to confirm dev server dependency scan completes without `style` condition error; stop server afterwards.
+- ✅ Document checklist completion statuses (mark completed items and promote to ✅ once validated by testing).


### PR DESCRIPTION
## Summary
- add an architecture note and execution checklist for the Excalidraw CSS resolution work
- switch the canvas shell to consume the package-exported `index.css`
- teach Vite and esbuild about Excalidraw's style/development/production export conditions to unblock dependency scanning

## Testing
- pnpm --filter @tljustdraw/web dev

------
https://chatgpt.com/codex/tasks/task_e_68d0f78651908323bc08302b00db25fb