### PR TITLE
Fix Excalidraw canvas blanking on load

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -94,12 +94,17 @@ main {
   display: flex;
   width: 100%;
   overflow: hidden;
+  min-height: 0;
+  min-width: 0;
 }
 
 .workspace-canvas {
   position: relative;
   flex: 1 1 auto;
+  display: flex;
   overflow: hidden;
+  min-height: 0;
+  min-width: 0;
 }
 
 .canvas-shell {
@@ -107,10 +112,17 @@ main {
   inset: 0;
   border-radius: 0;
   overflow: hidden;
+  display: flex;
+  width: 100%;
+  height: 100%;
 }
 
 .canvas-shell .tl-container {
   background: transparent;
+}
+
+.canvas-shell > .excalidraw {
+  flex: 1 1 auto;
 }
 
 .floating-panel-layer {

--- a/apps/web/src/components/canvas/CanvasShell.tsx
+++ b/apps/web/src/components/canvas/CanvasShell.tsx
@@ -27,6 +27,11 @@ const CanvasShell = ({ onAppReady, onSnapshot }: CanvasShellProps): JSX.Element 
       if (api) {
         apiRef.current = api;
         logger.info('Excalidraw API ready');
+        if (typeof window !== 'undefined') {
+          window.requestAnimationFrame(() => {
+            apiRef.current?.refresh();
+          });
+        }
         onAppReady?.(api);
       } else if (apiRef.current) {
         logger.info('Excalidraw API disconnected');

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import App from './App';
@@ -10,8 +9,4 @@ if (!rootElement) {
   throw new Error('Failed to find root element');
 }
 
-createRoot(rootElement).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+createRoot(rootElement).render(<App />);

--- a/docs/architecture/20250922T073215Z-canvas-refresh-stability.md
+++ b/docs/architecture/20250922T073215Z-canvas-refresh-stability.md
@@ -1,0 +1,69 @@
+# 2025-09-22T07:32:15Z — Canvas Refresh Stability Architecture
+
+> Hybrid knowledge graph synchronization unavailable in this environment; capturing architecture locally.
+
+## 1. Baseline Abstract Syntax Tree (AST) Snapshot
+
+```text
+apps/web/
+  src/
+    App.tsx                         # Holds canvas API + latest snapshot state, wires layout chrome
+    components/
+      canvas/CanvasShell.tsx       # Renders <Excalidraw>, forwards imperative API + snapshot callback
+      layout/WorkspaceLayout.tsx   # Places canvas slot, floating panels, share/settings chrome
+    app.css                        # Global layout + canvas container styling
+    hooks/
+      useAgentCollaborator.ts      # Observes Excalidraw snapshot + API for agent wiring
+    state/workspaceLayout.ts       # Zustand store controlling floating panel layout
+    types/canvas.ts                # Re-exported Excalidraw types + snapshot shape
+```
+
+### Key runtime relationships
+- `App.tsx` renders `WorkspaceLayout` and injects `<CanvasShell />` into the `canvasSlot` prop.
+- `CanvasShell` keeps a ref to the `ExcalidrawImperativeAPI` and emits `onAppReady` + `onSnapshot` callbacks.
+- Layout chrome (`WorkspaceLayout`, floating panels, drawers) live in absolutely/fixed-positioned layers atop the canvas container defined in `app.css`.
+
+## 2. Observed Issue
+- During initial mount the Excalidraw surface briefly renders and then collapses to a blank area. The UI chrome remains.
+- Root cause suspicion: the absolutely positioned canvas container changes dimensions immediately after layout chrome settles (header height, floating panel transforms). Excalidraw does not automatically refresh its internal stage when the host container's size updates outside of its control, leading to a zero-sized canvas.
+
+## 3. Proposed Remediation
+
+### 3.1 CanvasShell resilience
+- On `Excalidraw` API handshake, schedule a single `requestAnimationFrame` to invoke `api.refresh()` ensuring the stage reflows after layout settles.
+- Continue to emit `onAppReady` / `onSnapshot` without additional observers so we avoid nested update loops.
+- Maintain logging and API teardown semantics when the ref disconnects.
+
+### 3.2 Layout style guardrails
+- Guarantee the canvas wrapper can actually grow: enforce `min-height: 0` and `min-width: 0` on `.workspace-main` and `.workspace-canvas` so flexbox does not constrain the Excalidraw viewport.
+- Explicitly ensure `.canvas-shell` remains a flex child with full width/height to avoid inadvertent collapse.
+
+### 3.3 Render stabilisation
+- Remove React `StrictMode` from `apps/web/src/main.tsx` to prevent double-invocation of mount lifecycles that exacerbate Excalidraw's internal resize bookkeeping in development builds.
+
+## 4. Updated Component Interaction
+
+```mermaid
+sequenceDiagram
+    participant Layout as WorkspaceLayout
+    participant Shell as CanvasShell
+    participant Div as Canvas DIV
+    participant API as Excalidraw API
+
+    Layout->>Shell: render (onAppReady, onSnapshot)
+    Shell->>Div: render wrapper
+    Shell->>API: Excalidraw ref callback
+    API-->>Shell: imperative API ready
+    Shell->>API: requestAnimationFrame(refresh)
+    Shell->>Layout: onAppReady(api)
+```
+
+## 5. Data Flow / Responsibilities
+- `CanvasShell` now owns the initial API refresh kick-off while avoiding perpetual observers.
+- CSS changes guarantee flex parents do not clip the canvas.
+- Root rendering swaps out `StrictMode` to match production runtime and prevent duplicate mount phases.
+
+## 6. Risks & Mitigations
+- **API refresh timing**: relying on a single `requestAnimationFrame` assumes layout settles within one frame; additional layout shims can be added if needed.
+- **StrictMode removal**: reduces development diagnostics; acceptable trade-off due to third-party component instability under double-mount semantics.
+

--- a/docs/checklists/20250922T073215Z-canvas-refresh-stability.md
+++ b/docs/checklists/20250922T073215Z-canvas-refresh-stability.md
@@ -1,0 +1,24 @@
+# 2025-09-22T07:32:15Z — Canvas Refresh Stability Checklist
+
+## Preconditions
+- ✅ Confirm `pnpm install` executed (workspace deps ready).
+- ⚠️ Ensure dev server repro shows blank canvas after flash (optional sanity check).
+
+## Implementation Steps
+1. CanvasShell resilience
+   - [x] Update `apps/web/src/components/canvas/CanvasShell.tsx` to schedule a `requestAnimationFrame` refresh after the API resolves.
+   - ✅ Ensure the disconnect branch still nulls `apiRef.current` when the Excalidraw instance unmounts.
+
+2. Layout CSS guardrails
+   - [x] Modify `apps/web/src/app.css` to add `min-height: 0` / `min-width: 0` for `.workspace-main` and `.workspace-canvas` so flex layout cannot collapse the canvas.
+   - [x] Ensure `.canvas-shell` uses `display: flex` with full width/height, and its direct Excalidraw child flexes to fill the area.
+
+3. Render stabilisation
+   - [x] Update `apps/web/src/main.tsx` to drop the `StrictMode` wrapper around `<App />`.
+
+## Verification
+- ✅ Run `pnpm --filter web lint` to confirm lint passes.
+- ✅ Run `pnpm --filter web build` to ensure production build succeeds.
+- ⚠️ Manually verify via dev server or screenshot that the canvas remains visible (if feasible).
+- ✅ Update checklist statuses with ✅ once tests complete.
+


### PR DESCRIPTION
## Summary
- ensure the workspace flex containers cannot collapse and let the Excalidraw surface flex to fill the viewport
- schedule a single requestAnimationFrame refresh when the Excalidraw API becomes available and capture the architecture/checklist
- drop React StrictMode in the web entry point to avoid Excalidraw double-mount instabilities

## Testing
- pnpm --filter web lint
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68d0fa7fede88323821fc2dcd5ea5d9e