### PR TITLE
Improve model catalog fallback handling

### DIFF
--- a/apps/web/public/api/openrouter/models.json
+++ b/apps/web/public/api/openrouter/models.json
@@ -1,0 +1,36 @@
+{
+  "data": [
+    {
+      "id": "openrouter/x-ai/grok-4-fast:free",
+      "name": "Grok 4 Fast (OpenRouter)",
+      "description": "Default Grok 4 Fast free-tier model via OpenRouter.",
+      "context_length": 262144,
+      "pricing": {
+        "prompt": 0,
+        "completion": 0,
+        "currency": "USD"
+      },
+      "top_provider": {
+        "name": "x.ai"
+      }
+    },
+    {
+      "id": "openrouter/openai/gpt-4o-mini",
+      "name": "GPT-4o Mini",
+      "description": "Balanced OpenAI GPT-4o mini via OpenRouter.",
+      "context_length": 128000,
+      "top_provider": {
+        "name": "OpenAI"
+      }
+    },
+    {
+      "id": "openrouter/google/gemini-flash-1.5",
+      "name": "Gemini Flash 1.5",
+      "description": "Fast multimodal Gemini Flash 1.5.",
+      "context_length": 1048576,
+      "top_provider": {
+        "name": "Google"
+      }
+    }
+  ]
+}

--- a/apps/web/src/components/panels/ModelSelector.tsx
+++ b/apps/web/src/components/panels/ModelSelector.tsx
@@ -8,7 +8,7 @@ interface ModelSelectorProps {
 }
 
 const ModelSelector = ({ label = 'Model', onChange }: ModelSelectorProps): JSX.Element => {
-  const { models, activeModelId, setActiveModelId, loading, error } = useModelContext();
+  const { models, activeModelId, setActiveModelId, loading, error, source } = useModelContext();
 
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const nextId = event.target.value;
@@ -20,11 +20,18 @@ const ModelSelector = ({ label = 'Model', onChange }: ModelSelectorProps): JSX.E
     if (loading) {
       return 'Loading OpenRouter models…';
     }
-    if (error) {
-      return `Using fallback catalog (${error})`;
+
+    if (source === 'remote') {
+      return `${models.length} models available via OpenRouter`;
     }
-    return `${models.length} models available`;
-  }, [error, loading, models.length]);
+
+    if (source === 'static') {
+      return `${models.length} models available from static catalog`;
+    }
+
+    const fallbackReason = error ? ` (${error})` : '';
+    return `Using bundled catalog${fallbackReason}`;
+  }, [error, loading, models.length, source]);
 
   return (
     <div className="model-selector">

--- a/apps/web/src/context/ModelProvider.tsx
+++ b/apps/web/src/context/ModelProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo } from 'react';
 
-import { useModelCatalog } from '../hooks/useModelCatalog';
+import { CatalogSource, useModelCatalog } from '../hooks/useModelCatalog';
 import { OpenRouterModel } from '../state/models';
 
 interface ModelContextValue {
@@ -9,6 +9,7 @@ interface ModelContextValue {
   setActiveModelId: (modelId: string) => void;
   loading: boolean;
   error?: string;
+  source: CatalogSource;
 }
 
 const ModelContext = createContext<ModelContextValue | undefined>(undefined);
@@ -22,6 +23,7 @@ export const ModelProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       setActiveModelId: catalog.setActiveModelId,
       loading: catalog.loading,
       error: catalog.error,
+      source: catalog.source,
     }),
     [
       catalog.models,
@@ -29,6 +31,7 @@ export const ModelProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       catalog.setActiveModelId,
       catalog.loading,
       catalog.error,
+      catalog.source,
     ]
   );
 

--- a/apps/web/src/hooks/useModelCatalog.ts
+++ b/apps/web/src/hooks/useModelCatalog.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@shared-utils';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   DEFAULT_OPENROUTER_MODEL_ID,
@@ -11,12 +11,15 @@ import {
 
 const logger = createLogger({ name: '@tljustdraw/web/useModelCatalog' });
 
+export type CatalogSource = 'remote' | 'static' | 'bundled';
+
 interface UseModelCatalogResult {
   models: OpenRouterModel[];
   activeModelId: string;
   setActiveModelId: (modelId: string) => void;
   loading: boolean;
   error?: string;
+  source: CatalogSource;
 }
 
 const parseResponse = async (response: Response): Promise<OpenRouterModel[]> => {
@@ -35,53 +38,119 @@ const parseResponse = async (response: Response): Promise<OpenRouterModel[]> => 
   return data.map(normalizeOpenRouterModel);
 };
 
+const REMOTE_CATALOG_ENDPOINT =
+  (import.meta.env.VITE_OPENROUTER_MODEL_CATALOG_URL as string | undefined) ??
+  '/api/openrouter/models';
+const STATIC_CATALOG_ENDPOINT = '/api/openrouter/models.json';
+
 export const useModelCatalog = (): UseModelCatalogResult => {
   const [models, setModels] = useState<OpenRouterModel[]>(FALLBACK_OPENROUTER_MODELS);
   const [activeModelId, setActiveModelId] = useState<string>(DEFAULT_OPENROUTER_MODEL_ID);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
+  const [source, setSource] = useState<CatalogSource>('bundled');
+
+  const activeModelIdRef = useRef(activeModelId);
+  const hydrationRunRef = useRef(false);
+  useEffect(() => {
+    activeModelIdRef.current = activeModelId;
+  }, [activeModelId]);
 
   useEffect(() => {
+    if (hydrationRunRef.current) {
+      return;
+    }
+    hydrationRunRef.current = true;
+
     let cancelled = false;
     const controller = new AbortController();
 
     const hydrate = async () => {
       setLoading(true);
       setError(undefined);
+
+      const endpoints: Array<{ url: string; source: CatalogSource }> = [
+        { url: REMOTE_CATALOG_ENDPOINT, source: 'remote' },
+        { url: STATIC_CATALOG_ENDPOINT, source: 'static' },
+      ];
+
+      let lastError: Error | undefined;
+      let resolvedModels: OpenRouterModel[] | undefined;
+      let resolvedSource: CatalogSource | undefined;
+      let resolvedEndpoint: string | undefined;
+
       try {
-        const response = await fetch('/api/openrouter/models', {
-          method: 'GET',
-          headers: { Accept: 'application/json' },
-          signal: controller.signal,
-        });
-        const nextModels = await parseResponse(response);
-        if (!cancelled) {
-          setModels(nextModels);
-          if (!nextModels.some((model) => model.id === activeModelId)) {
-            const defaultModel = nextModels.find(
-              (model) => model.id === DEFAULT_OPENROUTER_MODEL_ID
-            );
-            setActiveModelId(defaultModel?.id ?? nextModels[0]?.id ?? DEFAULT_OPENROUTER_MODEL_ID);
+        for (const endpoint of endpoints) {
+          try {
+            const response = await fetch(endpoint.url, {
+              method: 'GET',
+              headers: { Accept: 'application/json' },
+              signal: controller.signal,
+            });
+            const nextModels = await parseResponse(response);
+            resolvedModels = nextModels;
+            resolvedSource = endpoint.source;
+            resolvedEndpoint = endpoint.url;
+            break;
+          } catch (attemptError) {
+            if (attemptError instanceof DOMException && attemptError.name === 'AbortError') {
+              throw attemptError;
+            }
+            const failure = attemptError as Error;
+            lastError = failure;
+            logger.warn('OpenRouter model catalog fetch failed', {
+              endpoint: endpoint.url,
+              error: failure.message,
+            });
           }
         }
-        logger.info('Hydrated OpenRouter models', {
-          count: nextModels.length,
-        });
-      } catch (fetchError) {
-        if (cancelled || (fetchError instanceof DOMException && fetchError.name === 'AbortError')) {
+      } catch (hydrateError) {
+        if (hydrateError instanceof DOMException && hydrateError.name === 'AbortError') {
           return;
         }
-        logger.warn('Falling back to bundled OpenRouter model catalog', {
-          error: (fetchError as Error).message,
-        });
-        setError((fetchError as Error).message);
-        setModels(FALLBACK_OPENROUTER_MODELS);
-        setActiveModelId(DEFAULT_OPENROUTER_MODEL_ID);
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+        lastError = (hydrateError as Error) ?? lastError;
       }
+
+      if (cancelled) {
+        return;
+      }
+
+      if (resolvedModels && resolvedSource) {
+        setModels(resolvedModels);
+        setSource(resolvedSource);
+
+        const currentActiveModelId = activeModelIdRef.current;
+        if (!resolvedModels.some((model) => model.id === currentActiveModelId)) {
+          const defaultModel = resolvedModels.find(
+            (model) => model.id === DEFAULT_OPENROUTER_MODEL_ID
+          );
+          setActiveModelId(
+            defaultModel?.id ?? resolvedModels[0]?.id ?? DEFAULT_OPENROUTER_MODEL_ID
+          );
+        }
+
+        logger.info(
+          resolvedSource === 'remote'
+            ? 'Hydrated OpenRouter models from remote endpoint'
+            : 'Hydrated OpenRouter models from static asset',
+          {
+            endpoint: resolvedEndpoint,
+            count: resolvedModels.length,
+          }
+        );
+        setLoading(false);
+        return;
+      }
+
+      setSource('bundled');
+      setError(lastError?.message ?? 'OpenRouter model catalog unavailable');
+      setModels(FALLBACK_OPENROUTER_MODELS);
+      setActiveModelId(DEFAULT_OPENROUTER_MODEL_ID);
+      logger.warn('Falling back to bundled OpenRouter model catalog', {
+        error: lastError?.message,
+        count: FALLBACK_OPENROUTER_MODELS.length,
+      });
+      setLoading(false);
     };
 
     void hydrate();
@@ -89,8 +158,9 @@ export const useModelCatalog = (): UseModelCatalogResult => {
     return () => {
       cancelled = true;
       controller.abort();
+      setLoading(false);
     };
-  }, [activeModelId]);
+  }, []);
 
   const setActiveModel = useCallback((modelId: string) => {
     setActiveModelId(modelId);
@@ -113,5 +183,6 @@ export const useModelCatalog = (): UseModelCatalogResult => {
     setActiveModelId: setActiveModel,
     loading,
     error,
+    source,
   };
 };

--- a/docs/architecture/2025-09-22T1449Z-model-catalog-resilience.md
+++ b/docs/architecture/2025-09-22T1449Z-model-catalog-resilience.md
@@ -1,0 +1,95 @@
+# Architecture Plan — 2025-09-22T14:49Z — Model catalog resilience & blank screen mitigation
+
+> NOTE: External hybrid knowledge graph, Neo4j, Postgres, and Qdrant integrations are unavailable in this execution environment. Architecture and checklist documents capture the intended structure; syncing to external systems must be performed manually later.
+
+## Repository Abstract Syntax Tree (AST) Snapshot
+
+```text
+apps/
+  web/
+    public/
+      api/openrouter/models.json     # New static catalog copy served with the app
+    src/
+      hooks/useModelCatalog.ts       # Catalog loader hook with remote + fallback logic
+      context/ModelProvider.tsx      # React context exposing catalog state
+      components/panels/ModelSelector.tsx  # UI consumer showing catalog status & dropdown
+      state/models.ts                # Types & fallback catalog constants
+```
+
+## Problem & Objectives
+
+- **Symptom:** Browser logs `Failed to load models (404)` and UI flashes before rendering a blank page.
+- **Root Cause Hypothesis:** Catalog fetching retries `/api/openrouter/models` on mount even when no backend route exists. The repeated failure chain leaves the UI without a stable catalog source in time for dependent components, allowing the view to tear down.
+- **Goals:**
+  1. Guarantee the catalog is populated synchronously from a bundled asset when the remote endpoint is unavailable.
+  2. Track the provenance of the active catalog (`remote`, `static`, `bundled`) for diagnostics/UI messaging.
+  3. Prevent multiple fetch attempts that could thrash state during startup.
+  4. Keep consuming components decoupled from fetch details while surfacing status to the UI instead of blanking.
+
+## Proposed Solution Overview
+
+1. **Static catalog asset** — Ship `apps/web/public/api/openrouter/models.json` mirroring `FALLBACK_OPENROUTER_MODELS` for environments without an API server.
+2. **Enhanced loader hook** — Extend `useModelCatalog` to:
+   - Attempt remote fetch (configurable via `VITE_OPENROUTER_MODEL_CATALOG_URL`).
+   - On failure, fall back to the static JSON asset before resorting to bundled constants.
+   - Track a `catalogSource` state (`'remote' | 'static' | 'bundled'`).
+   - Guard with a `didFetchRef` so the async workflow runs only once on mount.
+3. **Context contract update** — Propagate `catalogSource` through `ModelProvider` so consumers know which dataset is active.
+4. **UI feedback** — Update `ModelSelector` status text to incorporate `catalogSource` and surface fallback messaging instead of rendering nothing.
+
+## UML Component Diagram (Mermaid)
+
+```mermaid
+direction LR
+classDiagram
+    class useModelCatalog {
+      +models: OpenRouterModel[]
+      +activeModelId: string
+      +setActiveModelId(id)
+      +loading: boolean
+      +error?: string
+      +source: CatalogSource
+    }
+    class ModelProvider {
+      +value: ModelContextValue
+    }
+    class ModelSelector {
+      +renderStatus()
+      +onChange(modelId)
+    }
+    class StaticCatalogAsset
+
+    useModelCatalog --> StaticCatalogAsset : fallback
+    ModelProvider --> useModelCatalog
+    ModelSelector --> ModelProvider
+```
+
+## Mermaid Mind Map — Catalog Load Flow
+
+```mermaid
+mindmap
+  root((Catalog bootstrap))
+    Remote attempt
+      Endpoint: env or /api/openrouter/models
+      Success -> source=remote
+      Failure -> try static asset
+    Static asset
+      Path: /api/openrouter/models.json
+      Success -> source=static
+      Failure -> bundled fallback
+    Bundled fallback
+      Data: FALLBACK_OPENROUTER_MODELS
+      source=bundled
+    Context propagation
+      ModelProvider exposes models, activeId, status, source
+      ModelSelector surfaces dropdown + status text
+```
+
+## Implementation Notes
+
+- Reuse `normalizeOpenRouterModel` when parsing JSON from either remote or static asset.
+- When falling back, ensure the active model ID remains valid; default to `DEFAULT_OPENROUTER_MODEL_ID` when necessary.
+- Preserve logging but downgrade expected static fallback to `info` level to avoid alarming warnings for normal static deployments.
+- Provide typed `CatalogSource` union within the hook for clarity across the provider and UI.
+- Remember to import the new static asset directory by ensuring Vite serves `apps/web/public` (default behavior).
+

--- a/docs/checklists/2025-09-22T1449Z-model-catalog-resilience-checklist.md
+++ b/docs/checklists/2025-09-22T1449Z-model-catalog-resilience-checklist.md
@@ -1,0 +1,26 @@
+# Checklist — Model catalog resilience & blank screen mitigation (2025-09-22T14:49Z)
+
+> Legend: [ ] not started, [/] in progress, [x] done (untested), ✅ tested
+
+## Assets & Data Sources
+- [x] Create `apps/web/public/api/openrouter/models.json` mirroring `FALLBACK_OPENROUTER_MODELS` schema.
+
+## Hook Enhancements
+- [x] Update `apps/web/src/hooks/useModelCatalog.ts`:
+  - [x] Introduce `CatalogSource` union and `catalogSource` state.
+  - [x] Add hydration guard to prevent repeated fetch loops.
+  - [x] Attempt remote endpoint (`VITE_OPENROUTER_MODEL_CATALOG_URL` or `/api/openrouter/models`).
+  - [x] On failure, attempt static asset `/api/openrouter/models.json` before falling back to bundled constants.
+  - [x] Normalize models via `normalizeOpenRouterModel` and reconcile `activeModelId` validity.
+  - [x] Refine logging levels for static fallback vs. hard failure and populate `error` state appropriately.
+
+## Context Contract
+- [x] Extend `apps/web/src/context/ModelProvider.tsx` to expose `catalog.source`.
+
+## UI Feedback
+- [x] Adjust `apps/web/src/components/panels/ModelSelector.tsx` to read `source` and render contextual status messaging.
+
+## Verification
+- ✅ Run `pnpm --filter @tljustdraw/web lint`.
+- ⚠️ Run `pnpm --filter @tljustdraw/web test` (Vitest exits with code 1 because no test files are present).
+


### PR DESCRIPTION
## Summary
- add a static OpenRouter catalog asset served with the web bundle for deployments without an API route
- harden the `useModelCatalog` hook to try remote and static sources, expose the active catalog origin, and keep model selection valid
- surface catalog source status in the provider/UI and capture the design in updated architecture/checklist docs

## Testing
- pnpm --filter @tljustdraw/web lint
- pnpm --filter @tljustdraw/web test *(fails: Vitest exits with code 1 because no test files are present)*

------
https://chatgpt.com/codex/tasks/task_e_68d1602e23cc8323be0cb4e601193eba